### PR TITLE
Add reactStaticPagesData alias

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mdx } from '@mdx-js/react';
+import pagesData from 'reactStaticPagesData';
 
 /** Recursively convert an MDX-compatible HAST to JSX */
 export const hastToMdx = (node, assets, i = 0) => {
@@ -38,7 +39,6 @@ export const hastToMdx = (node, assets, i = 0) => {
 
 export const PageContext = React.createContext({
   page: null,
-  pages: null,
 });
 
 /** Returns the current page's markdown data */
@@ -49,5 +49,5 @@ export const useMarkdownPage = () => {
 
 /* Returns all page's nested markdown data */
 export const useMarkdownTree = () => {
-  return React.useContext(PageContext).pages;
+  return pagesData;
 };

--- a/src/loader.js
+++ b/src/loader.js
@@ -20,7 +20,6 @@ export default function loader(source) {
   const location = options.location || process.cwd();
   const pathPrefix = options.pathPrefix || '';
   const utils = stringifyRequest(this, require.resolve('./index.js'));
-  const pagesData = stringifyRequest(this, options.pagesDataFile);
   const processor = getMarkdownProcessor(options.remarkPlugins);
 
   // Compute the page's originalPath and path
@@ -108,7 +107,6 @@ export default function loader(source) {
   return `
     import React from "react";
     import Template from ${template};
-    import pagesData from ${pagesData};
     import { PageContext, hastToMdx } from ${utils};
 
     var assets = {
@@ -117,7 +115,7 @@ export default function loader(source) {
 
     var hast = ${JSON.stringify(hast)};
     var pageData = ${JSON.stringify(pageData)};
-    var context = { page: pageData, pages: pagesData };
+    var context = { page: pageData };
 
     export default function MarkdownTemplate(props) {
       var mdx = React.useMemo(() => hastToMdx(hast, assets), [hast, assets]);

--- a/src/node.api.js
+++ b/src/node.api.js
@@ -69,7 +69,6 @@ const staticPluginSourceMarkdown = (opts = {}) => ({
             remarkPlugins: opts.remarkPlugins,
             pathPrefix: opts.pathPrefix,
             defaultTemplate,
-            pagesDataFile,
             location,
           },
         },

--- a/src/node.api.js
+++ b/src/node.api.js
@@ -6,11 +6,13 @@ import { getPages } from './markdown';
 
 const writeFile = promisify(fs.writeFile);
 
+const pagesFileName = 'pages.json';
+
 const staticPluginSourceMarkdown = (opts = {}) => ({
   async getRoutes(_, { config }) {
     // Resolve target location from ROOT folder
     const location = path.resolve(config.paths.ROOT, opts.location);
-    const pagesDataFile = path.resolve(config.paths.ARTIFACTS, 'pages.json');
+    const pagesDataFile = path.resolve(config.paths.ARTIFACTS, pagesFileName);
 
     // Get page data for each discovered markdown file
     const pages = await getPages(
@@ -41,8 +43,16 @@ const staticPluginSourceMarkdown = (opts = {}) => ({
   webpack(webpackConfig, { config, defaultLoaders }) {
     // Resolve target location and template from ROOT folder
     const location = path.resolve(config.paths.ROOT, opts.location);
-    const pagesDataFile = path.resolve(config.paths.ARTIFACTS, 'pages.json');
+    const pagesDataFile = path.resolve(config.paths.ARTIFACTS, pagesFileName);
     const defaultTemplate = path.resolve(config.paths.ROOT, opts.template);
+
+    // Make the `pages` data available through an alias
+    Object.assign(webpackConfig.resolve.alias, {
+      reactStaticPagesData$: path.resolve(
+        config.paths.ARTIFACTS,
+        pagesFileName
+      ),
+    });
 
     // Create a rule that only applies to the discovered markdown files
     webpackConfig.module.rules[0].oneOf.unshift({


### PR DESCRIPTION
## About
Add `reactStaticPagesData` alias so that the pages data can be consumed outside of react-static if desired.

## Changes
- Add above alias
- Update `useMarkdownTree` to utilise alias instead of context
- Remove pages data from context