### PR TITLE
Fix missing file name when resolving title

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -24,9 +24,10 @@ export default function loader(source) {
 
   // Compute the page's originalPath and path
   const relative = path.relative(location, this.resourcePath);
+  const filename = path.basename(relative, '.md');
   const originalPath = path.join(
     path.dirname(relative),
-    path.basename(relative, '.md')
+    filename
   );
   const keyPath = (pathPrefix ? [pathPrefix] : [])
     .concat(originalPath.split(path.sep))
@@ -35,7 +36,7 @@ export default function loader(source) {
   // Parse the markdown contents
   const tree = processor.parse(source);
   const pageData = {
-    ...getPageData(tree),
+    ...getPageData(tree, filename),
     originalPath,
     key: keyPath[keyPath.length - 1],
     path: keyPath.join('/'),

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -101,7 +101,7 @@ export const getMarkdownProcessor = (plugins = []) => {
   return processor;
 };
 
-export const getPageData = tree => {
+export const getPageData = (tree, filename) => {
   const slugger = new GithubSlugger();
 
   // Parse the frontmatter yaml data to JSON
@@ -147,7 +147,7 @@ export const getPages = async (location, remarkPlugins, pathPrefix, order) => {
       // Parse the given markdown file into MAST
       const vfile = await readVFile(originalPath);
       const tree = processor.parse(vfile);
-      const { frontmatter, headings } = getPageData(tree);
+      const { frontmatter, headings } = getPageData(tree, filename);
 
       return {
         originalPath: path.join(dirname, filename),


### PR DESCRIPTION
There is a bug if the markdown files do not contains frontmatter:

This plugin will try to use `filename` as title which is not feed to `getPageData()` to generate title.

```
jxh@jxh-mbp unravel % yarn start
yarn run v1.22.5
$ react-static start
Starting Development Server...
Fetching Site Data...
[✓] Site Data Downloaded
Building Routes...
Importing routes from directory...
  ReferenceError: filename is not defined

  - markdown.js:162 getPageData
    [unravel]/[react-static-plugin-md-pages]/markdown.js:162:88

  - markdown.js:219 _callee$
    [unravel]/[react-static-plugin-md-pages]/markdown.js:219:40

  - runtime.js:63 tryCatch
    [unravel]/[regenerator-runtime]/runtime.js:63:40

  - runtime.js:293 Generator.invoke [as _invoke]
    [unravel]/[regenerator-runtime]/runtime.js:293:22

  - runtime.js:118 Generator.next
    [unravel]/[regenerator-runtime]/runtime.js:118:21

  - asyncToGenerator.js:3 asyncGeneratorStep
    [unravel]/[@babel]/runtime/helpers/asyncToGenerator.js:3:24

  - asyncToGenerator.js:25 _next
    [unravel]/[@babel]/runtime/helpers/asyncToGenerator.js:25:9
```